### PR TITLE
Mark gnome shell 3.36 as supported.

### DIFF
--- a/notes@maestroschan.fr/metadata.json
+++ b/notes@maestroschan.fr/metadata.json
@@ -8,7 +8,8 @@
 		"3.28",
 		"3.30",
 		"3.32",
-		"3.34"
+		"3.34",
+		"3.36"
 	],
 	"url": "https://github.com/maoschanz/notes-extension-gnome",
 	"uuid": "notes@maestroschan.fr",


### PR DESCRIPTION
I use this extension in Ubuntu 20.04, which has gnome 3.36. It seems to work when adding the version, but maybe there are other differences too between the latest on "extensions.gnome.org" and this git repo.
Thanks for this handy extension!